### PR TITLE
Add wiring instructions for the examples

### DIFF
--- a/examples/wiring.md
+++ b/examples/wiring.md
@@ -1,0 +1,10 @@
+# Wiring for the Example
+To get the example code to work, wire up two Teensy 3.x or 4.x boards as shown in the following table:
+
+| Master         | Slave          |
+|----------------|----------------|
+| GND            | GND            |
+| CS0 (Pin 10)   | CS0 (Pin 10)   |
+| MOSI0 (Pin 11) | MISO0 (Pin 12) |
+| MISO0 (Pin 12) | MOSI0 (Pin 11) |
+| SCK0 (Pin 13)  | SCK0 (Pin 13)  |


### PR DESCRIPTION
Reason: I had a hard time figuring out that the MISO and MOSI ports need to be swapped.

To make the examples more beginner-friendly, I added some wiring instructions.